### PR TITLE
chore: hide our products link since it's outdated

### DIFF
--- a/website/src/routes/+layout.svelte
+++ b/website/src/routes/+layout.svelte
@@ -47,7 +47,7 @@
     <NavHamburger />
     <NavUl>
       <NavLi href={`/${langSelected}`}>{$t('navigation.home')}</NavLi>
-      <NavLi href={`/${langSelected}/vara-varor-2`}>{$t('navigation.products')}</NavLi>
+      <!-- <NavLi href={`/${langSelected}/vara-varor-2`}>{$t('navigation.products')}</NavLi> -->
       <NavLi href={`/${langSelected}/om-ekolivs-2`}>{$t('navigation.about')}</NavLi>
       <NavLi href={`/${langSelected}/engagera-dig`}>{$t('navigation.engage')}</NavLi>
       <NavLi href={`/${langSelected}/kontakt`}>{$t('navigation.contact')}</NavLi>
@@ -67,9 +67,9 @@
     <div>
       <h2 class="mb-6 text-sm font-semibold text-gray dark:text-gray-100 uppercase">Ekolivs</h2>
       <FooterLinkGroup ulClass="text-gray-900 dark:text-gray-200">
-        <FooterLink liClass="mb-4" href={`/${langSelected}/vara-varor-2`}
+        <!-- <FooterLink liClass="mb-4" href={`/${langSelected}/vara-varor-2`}
           >{$t('navigation.products')}</FooterLink
-        >
+        > -->
         <FooterLink liClass="mb-4" href={`/${langSelected}/om-ekolivs-2`}
           >{$t('navigation.about')}</FooterLink
         >

--- a/website/src/routes/[...lang=locale]/vara-varor-2/+page.svelte
+++ b/website/src/routes/[...lang=locale]/vara-varor-2/+page.svelte
@@ -2,7 +2,7 @@
   import { t } from '$lib/translations';
 </script>
 
-<svelte-head>
+<!-- <svelte-head>
   <title>{$t('products.title')}</title>
   <meta name="description" content={$t('products.meta.description')} />
   <meta name="robots" content="index, follow" />
@@ -31,7 +31,6 @@
   Leveransen till butiken kommer huvudsakligen på torsdagar.
 </p>
 
-<!-- <img /> -->
 
 <p>
   Mjölksyrade grönsaker innehåller mycket vitaminer och mineraler. Dessutom bildas probiotika vid
@@ -47,7 +46,6 @@
 
 <h4 class="text-2xl font-extrabold my-2">Nötter och frön</h4>
 
-<!-- <img /> -->
 
 <p>Urvalet varierar, men du hittar ofta följande på Ekolivs:</p>
 
@@ -108,7 +106,6 @@
   på de konventionella odlingarna enligt föreningen Swedwatch.
 </p>
 
-<!-- <img /> -->
 
 <p>
   K’inal importerar kaffe från zapatistiska kooperativ i södra Mexiko. I nuläget från kooperativet
@@ -124,7 +121,6 @@
 
 <p>Te i varierande urval</p>
 
-<!-- <img /> -->
 
 <h4 class="text-2xl font-extrabold my-2">Sylt och marmelad</h4>
 
@@ -137,7 +133,6 @@
 <p>Pesto från la Bio Idea</p>
 <p>Chokladkräm från Biona Organic</p>
 
-<!-- <img /> -->
 
 <h4 class="text-2xl font-extrabold my-2">Oljor och vinäger</h4>
 
@@ -145,4 +140,5 @@
   Rapsolja, neutral och smaksatt<br />från Gunnarshögs gård på Österlen, på flaska och bag-in-box
 </p>
 
-<!-- <img /> -->
+<img />
+-->


### PR DESCRIPTION
We should be redesigning the page to display our suppliers instead.

Now the outdated data is just mostly wrong, so we should rather not display it for release.